### PR TITLE
Fixes the footer not staying on the bottom of the page

### DIFF
--- a/css/custom-styles.css
+++ b/css/custom-styles.css
@@ -1,3 +1,12 @@
+html {
+    position: relative;
+    min-height: 100%;
+}
+
+body {
+  margin-bottom: 75px; /* set to height of footer plus a little bit so stuff doesn't butt up right against it. */
+}
+
 .blog-post {
 	display: block;
 	width: 100%;
@@ -37,9 +46,12 @@
 	color: #fff;
 	font-size: 14px;
 	padding-top: 20px;
-	padding-bottom: 20px;
-	
-	margin-top: 35px;
+	padding-bottom: 20px;	
+	margin-top: 35px;    
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 60px;
 }
 
 .footer p {
@@ -82,18 +94,4 @@
 }
 .col-center {
     margin: 0 auto
-}
-
-html {
-  position: relative;
-  min-height: 100%;
-}
-body {
-  margin-bottom: 75px; /*set to height of footer plus a little bit so stuff doesn't butt up right against it.*/
-}
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 60px; /*height of footer*/
 }

--- a/css/custom-styles.css
+++ b/css/custom-styles.css
@@ -8,9 +8,9 @@ body {
 }
 
 .blog-post {
-	display: block;
-	width: 100%;
-	margin-bottom: 14px !important;
+    display: block;
+    width: 100%;
+    margin-bottom: 14px !important;
 }
 
 /* Medium devices (desktops, 992px and up) */
@@ -41,13 +41,13 @@ body {
 }
 
 .footer {
-	text-align: center;
-	background-color: #7fb199;
-	color: #fff;
-	font-size: 14px;
-	padding-top: 20px;
-	padding-bottom: 20px;	
-	margin-top: 35px;    
+    text-align: center;
+    background-color: #7fb199;
+    color: #fff;
+    font-size: 14px;
+    padding-top: 20px;
+    padding-bottom: 20px;	
+    margin-top: 35px;    
     position: absolute;
     bottom: 0;
     width: 100%;
@@ -55,8 +55,8 @@ body {
 }
 
 .footer p {
-	margin: 0px;
-	padding: 0px;
+    margin: 0px;
+    padding: 0px;
 }
 
 /*temporary styles for support lab */

--- a/css/custom-styles.css
+++ b/css/custom-styles.css
@@ -83,3 +83,17 @@
 .col-center {
     margin: 0 auto
 }
+
+html {
+  position: relative;
+  min-height: 100%;
+}
+body {
+  margin-bottom: 75px; /*set to height of footer plus a little bit so stuff doesn't butt up right against it.*/
+}
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 60px; /*height of footer*/
+}

--- a/css/custom-styles.css
+++ b/css/custom-styles.css
@@ -4,7 +4,7 @@ html {
 }
 
 body {
-  margin-bottom: 75px; /* set to height of footer plus a little bit so stuff doesn't butt up right against it. */
+    margin-bottom: 75px; /* set to height of footer plus a little bit so stuff doesn't butt up right against it. */
 }
 
 .blog-post {


### PR DESCRIPTION
Should fix issue #25. Footer will still be pushed by content if content is longer than the window.

Tested on Firefox Desktop and Firefox for Android. 